### PR TITLE
feat: localeToI18n 一并导出依赖包 dist/locale

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -7,6 +7,37 @@ const downloadNpmPackage = require('@kne/fetch-npm-package');
 const {select} = require('@inquirer/prompts');
 const args = process.argv.slice(2);
 
+const printHelp = () => {
+    console.log(`Usage:
+  npx @kne/npm-tools <command> [options]
+
+Commands:
+  packageInfo <name>              获取 npm 包信息
+  latestVersion <name>            获取 npm 包最新版本号
+  nextMajorVersion                将当前项目 version 升 major 并写回 package.json
+  nextMinorVersion                将当前项目 version 升 minor 并写回 package.json
+  nextPatchVersion                将当前项目 version 升 patch 并写回 package.json
+  download <name[@version]>       下载指定 npm 包
+  deploy                          执行 manifest 部署
+  deployPackage                   执行 package 部署
+  deployProject                   执行 project 部署
+  deployPrompts [target]          执行 prompts 部署
+  localeToI18n [options]          导出 locale 为 .i18n（详见该命令 -h）
+  entryHtml                       生成入口 HTML
+  manifest                        生成 manifest
+  init <project> [template]       使用模板初始化项目
+
+Options:
+  -h, --help                      打印帮助说明
+`);
+};
+
+const isLocaleToI18n = args[0] === 'localeToI18n' || args[0] === 'locale-to-i18n';
+if (!isLocaleToI18n && (args.includes('--help') || args.includes('-h'))) {
+    printHelp();
+    process.exit(0);
+}
+
 const script = args[0];
 
 console.log(`执行命令:${script || 'entryHtml'}`);

--- a/doc/api.md
+++ b/doc/api.md
@@ -32,16 +32,22 @@
 | `deployPackage` | - | 执行 package 部署 |
 | `deployProject` | - | 执行 project 部署 |
 | `deployPrompts` | `[type]` | 部署 prompts 文档 |
-| `localeToI18n` / `locale-to-i18n` | `[--root] [--out] [--include-server] [--dry-run]` | 将项目 `locale` 语言包导出为 IntlAdmin 可导入的 `.i18n` |
+| `localeToI18n` / `locale-to-i18n` | `[--root] [--out] [--include-server] [--dry-run]` | 将项目及依赖包（含 `@kne/react-intl` 且有 `dist/locale`）的语言包导出为 IntlAdmin `.i18n` |
 
 #### localeToI18n
 
-扫描 `**/locale/{zh-CN,en-US,...}.{js,json}`，按邻近 `withLocale` 的 `namespace`（缺省 `global`）合并，生成：
+扫描并合并两类语言包，按邻近 `withLocale` / `dist` 入口中的 `namespace`（缺省 `global`）生成 `.i18n`：
+
+1. 项目源码：`**/locale/{zh-CN,en-US,...}.{js,json}`
+2. `package.json` 依赖：依赖包自身含 `@kne/react-intl`，且 `dist` 下存在 `locale` 目录
+
+规则：
 
 - 文件名：`{namespace}.{locale}.i18n`
 - 正文：`code="value"`（每行一条）
 - 单文件：直接写入 `--out` 目录
 - 多文件：打包为 `{out}.zip`（如默认 `i18n-export.zip`）
+- 同 `namespace+locale+code` 冲突时，**项目源码覆盖依赖包**
 
 ```shell
 # 在项目根目录

--- a/lib/localeToI18n.js
+++ b/lib/localeToI18n.js
@@ -128,11 +128,171 @@ const findWithLocaleFile = localeDir => {
   return null;
 };
 
+const parseNamespaceFromSource = source => {
+  if (!source) return null;
+  const objectMatch = source.match(/namespace\s*:\s*['"]([^'"]+)['"]/);
+  if (objectMatch) return objectMatch[1].trim();
+  // createWithIntlProvider('zh-CN', messages, 'namespace')
+  const positional = source.match(
+    /createWithIntlProvider\s*\(\s*['"][^'"]+['"]\s*,\s*[^,]+,\s*['"]([^'"]+)['"]/
+  );
+  if (positional) return positional[1].trim();
+  return null;
+};
+
 const readNamespace = withLocalePath => {
   if (!withLocalePath) return 'global';
   const source = fs.readFileSync(withLocalePath, 'utf8');
-  const matched = source.match(/namespace\s*:\s*['"]([^'"]+)['"]/);
-  return matched ? matched[1].trim() : 'global';
+  return parseNamespaceFromSource(source) || 'global';
+};
+
+const resolvePackageDir = (root, name) => {
+  if (name.startsWith('@')) {
+    const [scope, pkg] = name.split('/');
+    return path.join(root, 'node_modules', scope, pkg);
+  }
+  return path.join(root, 'node_modules', name);
+};
+
+const packageDependsOnReactIntl = packageJson => {
+  const deps = {
+    ...(packageJson.dependencies || {}),
+    ...(packageJson.peerDependencies || {}),
+    ...(packageJson.devDependencies || {})
+  };
+  return Object.prototype.hasOwnProperty.call(deps, '@kne/react-intl');
+};
+
+const findLocaleDirsUnderDist = distDir => {
+  const dirs = [];
+  const walkDist = dir => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (e) {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.name === 'locale') {
+        dirs.push(full);
+        continue;
+      }
+      walkDist(full);
+    }
+  };
+  walkDist(distDir);
+  return dirs;
+};
+
+const resolveNamespaceNearLocale = (localeDir, packageDir) => {
+  const withLocalePath = findWithLocaleFile(localeDir);
+  if (withLocalePath) {
+    const ns = parseNamespaceFromSource(fs.readFileSync(withLocalePath, 'utf8'));
+    if (ns) return { namespace: ns, withLocalePath };
+  }
+
+  const searchFiles = [];
+  const distDir = path.join(packageDir, 'dist');
+  const parent = path.dirname(localeDir);
+  for (const dir of [parent, distDir, packageDir]) {
+    for (const name of [
+      'withLocale.js',
+      'withLocale.jsx',
+      'withLocale.ts',
+      'withLocale.tsx',
+      'index.js',
+      'index.modern.js'
+    ]) {
+      const full = path.join(dir, name);
+      if (fs.existsSync(full) && !searchFiles.includes(full)) {
+        searchFiles.push(full);
+      }
+    }
+  }
+
+  for (const file of searchFiles) {
+    const ns = parseNamespaceFromSource(fs.readFileSync(file, 'utf8'));
+    if (ns) return { namespace: ns, withLocalePath: file };
+  }
+
+  return { namespace: 'global', withLocalePath: null };
+};
+
+const collectLocaleFilesFromDir = (localeDir, { root, namespace, withLocalePath }) => {
+  const packs = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(localeDir, { withFileTypes: true });
+  } catch (e) {
+    return packs;
+  }
+  entries.forEach(entry => {
+    if (!entry.isFile()) return;
+    const matched = entry.name.match(LOCALE_FILE_RE);
+    if (!matched) return;
+    const file = path.join(localeDir, entry.name);
+    packs.push({
+      file,
+      locale: matched[1],
+      namespace,
+      withLocalePath,
+      relative: path.relative(root, file)
+    });
+  });
+  return packs;
+};
+
+/**
+ * 从项目 package.json 依赖中收集支持 @kne/react-intl 的包的 dist/locale
+ * 判定：依赖包自身 dependencies/peer/dev 含 @kne/react-intl，且 dist 下存在 locale 目录
+ */
+const collectDependencyLocalePacks = root => {
+  const packageJsonPath = path.join(root, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) return [];
+
+  let packageJson;
+  try {
+    packageJson = fs.readJsonSync(packageJsonPath);
+  } catch (e) {
+    return [];
+  }
+
+  const depNames = new Set([
+    ...Object.keys(packageJson.dependencies || {}),
+    ...Object.keys(packageJson.peerDependencies || {}),
+    ...Object.keys(packageJson.optionalDependencies || {})
+  ]);
+  depNames.delete('@kne/react-intl');
+
+  const packs = [];
+  depNames.forEach(name => {
+    const packageDir = resolvePackageDir(root, name);
+    const depPackageJsonPath = path.join(packageDir, 'package.json');
+    if (!fs.existsSync(depPackageJsonPath)) return;
+
+    let depPackageJson;
+    try {
+      depPackageJson = fs.readJsonSync(depPackageJsonPath);
+    } catch (e) {
+      return;
+    }
+    if (!packageDependsOnReactIntl(depPackageJson)) return;
+
+    const distDir = path.join(packageDir, 'dist');
+    if (!fs.existsSync(distDir)) return;
+
+    const localeDirs = findLocaleDirsUnderDist(distDir);
+    if (localeDirs.length === 0) return;
+
+    localeDirs.forEach(localeDir => {
+      const { namespace, withLocalePath } = resolveNamespaceNearLocale(localeDir, packageDir);
+      packs.push(...collectLocaleFilesFromDir(localeDir, { root, namespace, withLocalePath }));
+    });
+  });
+
+  return packs;
 };
 
 const collectLocalePacks = (root, { includeServer }) => {
@@ -211,8 +371,13 @@ const localeToI18n = async (input = []) => {
   多文件：打包为 {out}.zip（内含多个 .i18n）
   每行 code="value"
 
+扫描范围：
+  1. 项目源码 **/locale/{locale}.{js,json,...}
+  2. package.json 依赖中：自身依赖含 @kne/react-intl 且 dist 下存在 locale 目录的包
+
 命名空间：
-  向上查找 withLocale 中的 namespace，缺省为 global
+  向上查找 withLocale / dist index 中的 namespace，缺省为 global
+  同 key 冲突时项目源码覆盖依赖包
 `);
     return { outputs: [], conflicts: [] };
   }
@@ -221,10 +386,16 @@ const localeToI18n = async (input = []) => {
     throw new Error(`root 不存在: ${options.root}`);
   }
 
-  const packs = collectLocalePacks(options.root, options);
+  // 依赖包先收集，项目源码后收集（同 key 时项目覆盖依赖）
+  const depPacks = collectDependencyLocalePacks(options.root);
+  const projectPacks = collectLocalePacks(options.root, options);
+  const packs = [...depPacks, ...projectPacks];
   if (packs.length === 0) {
-    throw new Error('未找到 locale 语言包（**/locale/{locale}.{js,json,...}）');
+    throw new Error(
+      '未找到 locale 语言包（项目 **/locale 或依赖包 dist/locale，且依赖含 @kne/react-intl）'
+    );
   }
+  console.log(`locale sources: project=${projectPacks.length}, dependencies=${depPacks.length}`);
 
   const merged = new Map();
   const conflicts = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne/npm-tools",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "description": "发布npm包的一些工具脚本",
   "files": [
     "lib",


### PR DESCRIPTION
依赖包含 @kne/react-intl 且 dist 下有 locale 时纳入导出，项目源码覆盖同 key。